### PR TITLE
Rename worker executable parameter

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -63,6 +63,6 @@ Compiled services are found in the `build` folder.
 
 ```bash
 # From the project root
-./build/carta-spawn --worker_process build/worker --port 8080
+./build/carta-spawn --worker_exec build/worker --port 8080
 ./build/carta-ctl --spawner_address http://localhost:8080 --port 8081
 ```

--- a/config.toml.example
+++ b/config.toml.example
@@ -72,8 +72,8 @@ redirect_url = ""
 # ============================================================================
 [spawner]
 
-# Path or command to the CARTA backend binary
-worker_process = "carta_backend"
+# Path or command to the CARTA backend executable
+worker_exec = "carta_backend"
 
 # Timeout duration for spawning worker processes
 timeout = "5s"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,10 +47,10 @@ type ControllerConfig struct {
 }
 
 type SpawnerConfig struct {
-	WorkerProcess string        `mapstructure:"worker_process"`
-	Timeout       time.Duration `mapstructure:"timeout"`
-	Port          int           `mapstructure:"port"`
-	Hostname      string        `mapstructure:"hostname"`
+	WorkerExec string        `mapstructure:"worker_exec"`
+	Timeout    time.Duration `mapstructure:"timeout"`
+	Port       int           `mapstructure:"port"`
+	Hostname   string        `mapstructure:"hostname"`
 }
 
 // Config holds common configuration values shared across all services
@@ -79,7 +79,7 @@ func setControllerDefaults(v *viper.Viper) {
 }
 
 func setSpawnerDefaults(v *viper.Viper) {
-	v.SetDefault("spawner.worker_process", "carta-worker")
+	v.SetDefault("spawner.worker_exec", "carta-worker")
 	v.SetDefault("spawner.timeout", 5*time.Second)
 	v.SetDefault("spawner.port", 8080)
 	v.SetDefault("spawner.hostname", "")

--- a/services/carta-spawn/main.go
+++ b/services/carta-spawn/main.go
@@ -38,18 +38,18 @@ func main() {
 	pflag.String("log_level", "info", "Log level (debug|info|warn|error)")
 	pflag.Int("port", 8080, "HTTP server port")
 	pflag.String("hostname", "", "Hostname to listen on")
-	pflag.String("worker_process", "carta_backend", "Path to worker binary")
+	pflag.String("worker_exec", "carta_backend", "Path to worker executable")
 	pflag.Int("timeout", 5, "Spawn timeout in seconds")
 	pflag.String("override", "", "Override simple config values (string, int, bool) as comma-separated key:value pairs (e.g., spawner.port:9000,log_level:debug)")
 
 	pflag.Parse()
 
 	config.BindFlags(map[string]string{
-		"log_level":      "log_level",
-		"port":           "spawner.port",
-		"hostname":       "spawner.hostname",
-		"worker_process": "spawner.worker_process",
-		"timeout":        "spawner.timeout",
+		"log_level":   "log_level",
+		"port":        "spawner.port",
+		"hostname":    "spawner.hostname",
+		"worker_exec": "spawner.worker_exec",
+		"timeout":     "spawner.timeout",
 	})
 
 	cfg := config.Load(pflag.Lookup("config").Value.String(), pflag.Lookup("override").Value.String())
@@ -82,7 +82,7 @@ func main() {
 
 		slog.Info("Process started", "baseFolder", reqBody.BaseFolder)
 
-		cmd, port, err := processHelpers.SpawnWorker(ctx, cfg.Spawner.WorkerProcess, cfg.Spawner.Timeout, reqBody.BaseFolder)
+		cmd, port, err := processHelpers.SpawnWorker(ctx, cfg.Spawner.WorkerExec, cfg.Spawner.Timeout, reqBody.BaseFolder)
 		spawnerDuration := time.Since(startTime)
 		if err != nil {
 			slog.Error("Error spawning worker on free port", "error", err)


### PR DESCRIPTION
One running worker instance is a process; the program is an executable. I also replaced "binary" in the descriptions; the executable may not be a binary file.