### PR TITLE
Changed default location of config file to /etc/carta/config.toml

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -66,3 +66,13 @@ Compiled services are found in the `build` folder.
 ./build/carta-spawn --worker_process build/worker --port 8080
 ./build/carta-ctl --spawner_address http://localhost:8080 --port 8081
 ```
+
+## Configure
+
+An [example configuration file](config.toml.example) is provided. By default, services look for configuration in `/etc/carta/config.toml`. You can specify a different location with a command line parameter.
+
+```bash
+# From the project root
+./build/carta-spawn --config=./config.toml
+./build/carta-ctl --config=./config.toml
+```

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,5 +1,5 @@
 # CARTA Go Configuration Example
-# Copy this file to config.toml and adjust values as needed
+# Copy this file to /etc/carta/config.toml and adjust values as needed
 # Configuration can also be set via environment variables with CARTA_ prefix
 # Example: CARTA_CONTROLLER_PORT=8081
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,7 +100,7 @@ func ConfigureViper() {
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.SetConfigName("config")
-	viper.AddConfigPath(".")
+	viper.AddConfigPath("/etc/carta")
 }
 
 func init() {

--- a/services/carta-ctl/main.go
+++ b/services/carta-ctl/main.go
@@ -246,7 +246,7 @@ func main() {
 	id := uuid.New()
 	slog.Info("Starting controller", "uuid", id.String())
 
-	pflag.String("config", "", "Path to config file (default: ./config.toml)")
+	pflag.String("config", "", "Path to config file (default: /etc/carta/config.toml)")
 	pflag.String("log_level", "info", "Log level (debug|info|warn|error)")
 	pflag.Int("port", 8081, "TCP server port")
 	pflag.String("hostname", "", "Hostname to listen on")

--- a/services/carta-spawn/main.go
+++ b/services/carta-spawn/main.go
@@ -34,7 +34,7 @@ func main() {
 	id := uuid.New()
 	slog.Info("Starting spawner", "uuid", id.String())
 
-	pflag.String("config", "", "Path to config file (default: ./config.toml)")
+	pflag.String("config", "", "Path to config file (default: /etc/carta/config.toml)")
 	pflag.String("log_level", "info", "Log level (debug|info|warn|error)")
 	pflag.Int("port", 8080, "HTTP server port")
 	pflag.String("hostname", "", "Hostname to listen on")


### PR DESCRIPTION
I have *replaced* the search path with `/etc/carta` and did not keep the current directory as a search path. I don't think that it's a good idea to override the global config if there happens to be a file with a particular name in the current directory. It may be a good idea to add a local default directory with a higher precedence, but it should be a fixed location (like `~/.config/carta`).

It's still possible to set a custom config file on the commandline, as before.