### PR TITLE
Enforce gofmt formatting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,4 +27,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4.0 
+          version: v2.4.0

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,16 +8,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-  check-formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-      - run:
-          make format
   check-linting:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,4 +27,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4.0
+          version: v2.4.0 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,4 @@ version: "2"
 formatters:
   enable:
     - gofmt
+  

--- a/services/carta-ctl/internal/auth/pamwrap/pamwrap.go
+++ b/services/carta-ctl/internal/auth/pamwrap/pamwrap.go
@@ -3,8 +3,8 @@ package pamwrap
 import (
 	"context"
 	"errors"
-	"net/http"
 	"log/slog"
+	"net/http"
 
 	"github.com/CARTAvis/go-carta/pkg/config"
 	"github.com/CARTAvis/go-carta/services/carta-ctl/internal/auth"


### PR DESCRIPTION
Adds a check to golangci-int config to ensure that the results pass `gofmt`'s checks