### PR TITLE
Use an explicit path to the default config file.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,8 +99,7 @@ func ConfigureViper() {
 	viper.SetEnvPrefix("CARTA")
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.SetConfigName("config")
-	viper.AddConfigPath("/etc/carta")
+	viper.SetConfigFile("/etc/carta/config.toml")
 }
 
 func init() {


### PR DESCRIPTION
There's currently no way to restrict file extensions when searching for a config file basename in a list of directories. All supported extensions are searched in order according to an internal list in viper, and json comes before toml, which means that if a `config.json` file is present in `/etc/carta` it will be selected. This PR simplifies the viper config and directly sets the path to the default config file location.