### PR TITLE
Don't fail if default config file is not found.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -119,9 +118,8 @@ func Load(configPath string, overrideStr string) *Config {
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		// Ignore file not found errors (config is optional)
-		var configFileNotFoundError viper.ConfigFileNotFoundError
-		if !errors.As(err, &configFileNotFoundError) {
+		// Ignore failure to read default config (config is optional)
+		if configPath != "" {
 			slog.Error("Failed to read config file", "error", err, "config_file", viper.ConfigFileUsed())
 			os.Exit(1)
 		}


### PR DESCRIPTION
Fixes #41.

* We no longer search a path for config files, so we should no longer check for this type of error to distinguish between the default and explicit config file cases. If we ever put this back, we should update the error name (the old one is deprecated).
* Instead, we check (again) if the config parameter was set, so that we only fail if an explicitly provided file does not exist.

This should be consistent with the previous behaviour.