### PR TITLE
Allow CARTA to run outside of top-level of domain

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -38,6 +38,11 @@ frontend_dir = ""
 # Address of the spawner service. If this is empty, the controller will determine the address from the spawner hostname and port
 spawner_address = "http://localhost:8080"
 
+# If exposing the controller to users other than at the top level of a domain the controller must tell the frontend where to find interfaces
+# - If the controller is accessed at http://mydomain.tld/ the default should suffice
+# - If the controller is accessed at, e.g., http://mydomain.tld/carta/ this should then be set to "/carta/api"
+api_prefix = "/api"
+
 # ----------------------------------------------------------------------------
 # PAM Authentication Configuration (when auth_mode = "pam" or "both")
 # ----------------------------------------------------------------------------

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type ControllerConfig struct {
 	SpawnerAddress     string     `mapstructure:"spawner_address"`
 	AuthMode           AuthMode   `mapstructure:"auth_mode"`
 	DBConnectionString string     `mapstructure:"db_conn_string"`
+	ApiPrefix		   string     `mapstructure:"api_prefix"`
 }
 
 type SpawnerConfig struct {
@@ -77,6 +78,8 @@ func setControllerDefaults(v *viper.Viper) {
 	v.SetDefault("controller.oidc.client_secret", "")
 	v.SetDefault("controller.oidc.redirect_url", "")
 	v.SetDefault("controller.db_conn_string", "")
+	v.SetDefault("controller.api_prefix", "/api")
+
 }
 
 func setSpawnerDefaults(v *viper.Viper) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,7 +43,7 @@ type ControllerConfig struct {
 	SpawnerAddress     string     `mapstructure:"spawner_address"`
 	AuthMode           AuthMode   `mapstructure:"auth_mode"`
 	DBConnectionString string     `mapstructure:"db_conn_string"`
-	ApiPrefix		   string     `mapstructure:"api_prefix"`
+	ApiPrefix          string     `mapstructure:"api_prefix"`
 }
 
 type SpawnerConfig struct {

--- a/services/carta-ctl/main.go
+++ b/services/carta-ctl/main.go
@@ -398,7 +398,7 @@ func main() {
 
 		cfg := map[string]string{
 			//"dashboardAddress": "/dashboard", // no dashboard
-			"apiAddress": "/api",
+			"apiAddress": cfg.Controller.ApiPrefix,
 			//"tokenRefreshAddress":  "/api/auth/refresh",
 			//"logoutAddress": "/api/auth/logout",
 			//"authPath":      "/api/auth/refresh",


### PR DESCRIPTION
Resolves #47.

When CARTA is run at a path like https://mydomain.tld/carta/ the frontend will load the `/config` of the controller (which reverse proxy rewriting will likely result in the client already receiving the controller's `/config`.  However, the frontend then looks up the API path in there which reverse proxy configurations are unlikely to have modified.

This option adds an `api_prefix` option to the controller section of the config file, and modifies the `/config` endpoint handler to return this value to the client.